### PR TITLE
Criação de queries para status do Freepost e ajustes na ORM

### DIFF
--- a/src/main/java/com/cea/controller/FreepostController.java
+++ b/src/main/java/com/cea/controller/FreepostController.java
@@ -62,14 +62,15 @@ public class FreepostController {
 	}
 
 	@GetMapping("/")
-	public ResponseEntity<Page<FreePost>> findAll(@RequestParam(value = "page", defaultValue = "0") Integer page,
+	public ResponseEntity<Page<FreePost>> findAllPaged(@RequestParam(value = "page", defaultValue = "0") Integer page,
 			@RequestParam(value = "linesPerPage", defaultValue = "10") Integer linesPerPage,
 			@RequestParam(value = "direction", defaultValue = "ASC") String direction,
 			@RequestParam(value = "orderBy", defaultValue = "createdAt") String orderBy,
-			@RequestParam(value = "title", defaultValue = "") String title) {
+			@RequestParam(value = "title", defaultValue = "") String title,
+			@RequestParam(value = "status", defaultValue = "") String status){
 		Pageable pageRequest = PageRequest.of(page, linesPerPage, Direction.valueOf(direction), orderBy);
 
-		Page<FreePost> freePosts = freePostService.findAllByPage(title, pageRequest);
+		Page<FreePost> freePosts = freePostService.findAllPaged(title, status, pageRequest);
 
 		return ResponseEntity.ok().body(freePosts);
 	}

--- a/src/main/java/com/cea/models/FreePost.java
+++ b/src/main/java/com/cea/models/FreePost.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
@@ -43,7 +44,7 @@ public class FreePost implements Serializable {
 	private String updatedBy;
 
 	@JsonIgnore
-	@OneToMany(mappedBy = "freePost")
+	@OneToMany(fetch = FetchType.EAGER, mappedBy = "freePost")
 	private List<HistoricStatusFreePost> historicStatusFreePost = new ArrayList<>();
 
 }

--- a/src/main/java/com/cea/repository/FreePostRepository.java
+++ b/src/main/java/com/cea/repository/FreePostRepository.java
@@ -13,5 +13,7 @@ public interface FreePostRepository extends JpaRepository<FreePost, UUID> {
 
 	Page<FreePost> findByTitleContaining(String title, Pageable pageRequest);
 	List<FreePost> findByStatusTrue();
+	Page<FreePost> findByTitleContainingAndStatusIs(String title, Boolean status, Pageable pageRequest);
+	Page<FreePost> findByStatusIs(Boolean status, Pageable pageRequest);
 
 }

--- a/src/main/java/com/cea/services/FreePostService.java
+++ b/src/main/java/com/cea/services/FreePostService.java
@@ -72,9 +72,20 @@ public class FreePostService {
 	 * FINDALL
 	 * * * * */
 
-	public Page<FreePost> findAllByPage(String title, Pageable pageRequest) {
-		if (!title.equals(""))
+	public Page<FreePost> findAllPaged(String title, String status, Pageable pageRequest) {
+		if (!title.equals("") && (status.equals("") || status.equals("all")))
 			return freePostRepository.findByTitleContaining(title, pageRequest);
+
+		if (!status.equals("") && !status.equals("all") && title.equals("")) {
+			Boolean statusBoolean = status.equals("online") ? true : false;
+			return freePostRepository.findByStatusIs(statusBoolean, pageRequest);
+		}
+
+		if (!status.equals("") && !status.equals("all") && !title.equals("")) {
+			Boolean statusBoolean = status.equals("online") ? true : false;
+			return freePostRepository.findByTitleContainingAndStatusIs(title, statusBoolean, pageRequest);
+		}
+
 		return freePostRepository.findAll(pageRequest);
 	}
 


### PR DESCRIPTION
1. Criada a busca por _status_ do Freepost;

> Esta busca será realizada quando o usuário solicitar filtragem somente por _status_

2. Criada a busca por _status_ e _title_ do freepost;

> Esta busca será realizada quando o usuário solicitar filtragem por _status_ e por _title_ simultaneamente

3. Ajustes realizados no Service e Controller para lidarem com queries que contenham parametros de _status_ e/ou _title_
4. Ajuste no relacionamento entre FreePost e HistoricStatusFreepost, ajustando o _fetchType_ de _lazyLoading_ para _eager_ para solucionar problemas na edição e deleção de FreePosts.